### PR TITLE
Add battle request index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -37,6 +37,15 @@
         { "fieldPath": "creatorBId", "order": "ASCENDING" },
         { "fieldPath": "dateTime", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "battleRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "receiverId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a composite Firestore index for battleRequests

## Testing
- `npm run lint` *(fails: deleteDoc not used, unexpected any, etc.)*
- `npm run typecheck` *(fails: Module '@/types' has no exported member, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6848d76dc954832d81a435b0467db74d